### PR TITLE
Add ARM FVP emulators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,42 @@
 FROM ghcr.io/zephyrproject-rtos/ci:v0.23.0
+
+ARG FVP_AEMV8R_VERSION=11.17_32
+ARG FVP_AEMVA_VERSION=11.17_21
+ARG FVP_SSE300_VERSION=11.16_26
+ARG WGET_ARGS="-q --show-progress --progress=bar:force:noscroll --no-check-certificate"
+
+# Install ARM Fixed Virtual Platform (FVP) emulators
+RUN mkdir -p /opt/FVP && \
+	mkdir -p /opt/FVP/bin
+
+ENV ARMFVP_BIN_PATH=/opt/FVP/bin
+
+## Install Armv8-R AEM FVP emulator
+RUN mkdir -p /opt/FVP/FVP_BaseR_AEMv8R && \
+	cd /opt/FVP/FVP_BaseR_AEMv8R && \
+	wget ${WGET_ARGS} https://developer.arm.com/-/media/Files/downloads/ecosystem-models/FVP_Base_AEMv8R_${FVP_AEMV8R_VERSION}.tgz && \
+	tar xf FVP_Base_AEMv8R_${FVP_AEMV8R_VERSION}.tgz && \
+	rm -f FVP_Base_AEMv8R_${FVP_AEMV8R_VERSION}.tgz && \
+	cd /opt/FVP/bin && \
+	ln -s /opt/FVP/FVP_BaseR_AEMv8R/AEMv8R_base_pkg/models/Linux64_GCC-9.3/FVP_BaseR_AEMv8R
+
+## Install Armv-A Base RevC AEM FVP emulator
+RUN mkdir -p /opt/FVP/FVP_Base_RevC-2xAEMvA && \
+	cd /opt/FVP/FVP_Base_RevC-2xAEMvA && \
+	wget ${WGET_ARGS} https://developer.arm.com/-/media/Files/downloads/ecosystem-models/FVP_Base_RevC-2xAEMvA_${FVP_AEMVA_VERSION}.tgz && \
+	tar xf FVP_Base_RevC-2xAEMvA_${FVP_AEMVA_VERSION}.tgz && \
+	rm -f FVP_Base_RevC-2xAEMvA_${FVP_AEMVA_VERSION}.tgz && \
+	cd /opt/FVP/bin && \
+	ln -s /opt/FVP/FVP_Base_RevC-2xAEMvA/Base_RevC_AEMvA_pkg/models/Linux64_GCC-9.3/FVP_Base_RevC-2xAEMvA
+
+## Install Corstone-300 MPS3 FVP emulator
+RUN mkdir -p /opt/FVP/FVP_Corstone_SSE-300_Ethos-U55 && \
+	cd /opt/FVP/FVP_Corstone_SSE-300_Ethos-U55 && \
+	wget ${WGET_ARGS} https://developer.arm.com/-/media/Arm%20Developer%20Community/Downloads/OSS/FVP/Corstone-300/FVP_Corstone_SSE-300_${FVP_SSE300_VERSION}.tgz && \
+	tar xf FVP_Corstone_SSE-300_${FVP_SSE300_VERSION}.tgz && \
+	rm -f FVP_Corstone_SSE-300_${FVP_SSE300_VERSION}.tgz && \
+	./FVP_Corstone_SSE-300.sh --no-interactive --i-agree-to-the-contained-eula -d . && \
+	rm -f FVP_Corstone_SSE-300.sh && \
+	cd /opt/FVP/bin && \
+	ln -s /opt/FVP/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U55 && \
+	ln -s /opt/FVP/FVP_Corstone_SSE-300_Ethos-U55/models/Linux64_GCC-6.4/FVP_Corstone_SSE-300_Ethos-U65


### PR DESCRIPTION
This commit adds the installation steps for the ARM Fixed Virtual
Platform (FVP) emulators:

* FVP_BaseR_AEMv8R
* FVP_Base_RevC-2xAEMvA
* FVP_Corstone_SSE-300_Ethos-U55

The ARM FVP is required for testing the following Zephyr boards:

* fvp_baser_aemv8r
* fvp_baser_aemv8r_aarch32
* fvp_base_revc_2xaemv8a
* mps3_an547

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>