### PR TITLE
Use base image v0.23.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/zephyrproject-rtos/ci:v0.23.0
+FROM ghcr.io/zephyrproject-rtos/ci:v0.23.3
 
 ARG FVP_AEMV8R_VERSION=11.17_32
 ARG FVP_AEMVA_VERSION=11.17_21


### PR DESCRIPTION
This commit updates the private CI Docker image to use the public CI
Docker image v0.23.3 as the base image.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>